### PR TITLE
Fix 1.8 updating the Player object at the start of the tick

### DIFF
--- a/fabric-1.19.4/build.gradle
+++ b/fabric-1.19.4/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.10-SNAPSHOT'
+	id 'fabric-loom' version "1.11-SNAPSHOT"
 }
 
 loom.runs.client.runDir = "../runs/run"

--- a/fabric-1.20.4/build.gradle
+++ b/fabric-1.20.4/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.10-SNAPSHOT'
+    id 'fabric-loom' version "1.11-SNAPSHOT"
 }
 
 loom.runs.client.runDir = "../runs/run"

--- a/fabric-1.20.6/build.gradle
+++ b/fabric-1.20.6/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.10-SNAPSHOT'
+    id 'fabric-loom' version "1.11-SNAPSHOT"
 }
 
 loom.runs.client.runDir = "../runs/run"

--- a/fabric-1.21.3/build.gradle
+++ b/fabric-1.21.3/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.10-SNAPSHOT'
+    id 'fabric-loom' version "1.11-SNAPSHOT"
 }
 
 loom.runs.client.runDir = "../runs/run"

--- a/fabric-1.21.5/build.gradle
+++ b/fabric-1.21.5/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.10-SNAPSHOT'
+    id 'fabric-loom' version "1.11-SNAPSHOT"
 }
 
 loom.runs.client.runDir = "../runs/run"

--- a/fabric-1.21.6/build.gradle
+++ b/fabric-1.21.6/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.10-SNAPSHOT'
+    id 'fabric-loom' version "1.11-SNAPSHOT"
 }
 
 loom.runs.client.runDir = "../runs/run"

--- a/fabric-1.21/build.gradle
+++ b/fabric-1.21/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.10-SNAPSHOT'
+    id 'fabric-loom' version "1.11-SNAPSHOT"
 }
 
 loom.runs.client.runDir = "../runs/run"

--- a/forge-1.8.9/build.gradle
+++ b/forge-1.8.9/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'xyz.wagyourtail.unimined' version '1.2.6'
+    id 'xyz.wagyourtail.unimined' version '1.4.1'
 }
 
 unimined.useGlobalCache = false

--- a/forge-1.8.9/src/main/java/io/github/kurrycat/mpkmod/compatibility/forge_1_8/EventListener.java
+++ b/forge-1.8.9/src/main/java/io/github/kurrycat/mpkmod/compatibility/forge_1_8/EventListener.java
@@ -82,7 +82,7 @@ public class EventListener {
         if (e.type != TickEvent.Type.CLIENT) return;
         if (e.side != Side.CLIENT) return;
 
-        if (mcPlayer != null && e.phase == TickEvent.Phase.START) {
+        if (mcPlayer != null && e.phase == TickEvent.Phase.END) {
             AxisAlignedBB playerBB = mcPlayer.getEntityBoundingBox();
             new Player()
                     .setPos(new Vector3D(mcPlayer.posX, mcPlayer.posY, mcPlayer.posZ))

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
In Forge 1.8.9, the `Player` object is updated at the start of the tick, whereas other versions update it at the end. This can cause inconsistent behavior across versions for modules that rely on the `Player` object updating at a specific point in the tick.